### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -3,9 +3,11 @@ version: 2.1
 description: |
   Run screenshot tests via happo.io in your project. API tokens are read from
   $HAPPO_API_KEY and $HAPPO_API_SECRET, or directly from `apiKey` and `apiToken`
-  if you have them listed in your `.happo.js` config. The source for this Orb is
-  available at https://github.com/happo/happo-circleci-orb.
-
+  if you have them listed in your `.happo.js` config.
+  
+display:
+    source_url: https://github.com/happo/happo-circleci-orb
+    home_url: https://happo.io/
 commands:
   run_happo:
     description: |


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.